### PR TITLE
Fix Ogres cost view and Gnnoblar TV cost

### DIFF
--- a/Ogres.cat
+++ b/Ogres.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f23e9ca0-d048-437b-944b-acfe2f8535b7" name="Ogre Team" revision="31" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@xerus101, @Dr. Toboggan, or @crazydude11" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="bfef4c13-8961-4056-a7ab-30a35cfaf51c" gameSystemRevision="37" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f23e9ca0-d048-437b-944b-acfe2f8535b7" name="Ogre Team" revision="32" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@xerus101, @Dr. Toboggan, or @crazydude11" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="bfef4c13-8961-4056-a7ab-30a35cfaf51c" gameSystemRevision="37" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>At face value, the thought of an Ogre Blood Bowl team is enough to fill most players with dread. Thankfully, the reality never quite lives up to their worst fears. For starters, most Ogres are incredibly dense. Just getting them to all turn up at the same time is a mammoth task. Not to mention that very few coaches can afford to field more than a few Ogres at a time, meaning that most Ogre teams are bulked out with Gnoblars. Then there’s the fact that, no matter how much you train them, the moment the whistle goes, most Ogres forget everything and try to pound their opponents into a bloody mess. Coaches who know what they’re doing can turn this to their advantage, but it’s a rare sight to see an Ogre team performing consistently.</readme>
   <categoryEntries>
     <categoryEntry id="72d9-56a6-76ad-260c" name="Gnoblar Lineman" publicationId="46da-ba61-6439-83e5" hidden="false">
@@ -1076,7 +1076,7 @@
       </entryLinks>
       <costs>
         <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0.0"/>
-        <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0.0"/>
+        <cost name=" TV" typeId="ffff-7836-9be4-196c" value="15000.0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -1659,7 +1659,7 @@
         <characteristic name="Skills &amp; Traits" typeId="aa6d-1678-d4d2-a97d">Bone Head, Mighty Blow (+1), Thick Skull, Throw Team-mate</characteristic>
         <characteristic name="Primary" typeId="fda4-6261-f0d2-ba0d">S</characteristic>
         <characteristic name="Secondary" typeId="9491-8b10-7b30-9358">AGP</characteristic>
-        <characteristic name="Cost" typeId="ee01-7448-8c3f-a882">140000</characteristic>
+        <characteristic name="Cost" typeId="ee01-7448-8c3f-a882">145000</characteristic>
       </characteristics>
     </profile>
     <profile id="c3bb-1f58-8411-160f" name="Gnoblar Lineman" publicationId="46da-ba61-6439-83e5" page="121" hidden="false" typeId="6abd-9371-31b8-653a" typeName="Player">
@@ -1685,7 +1685,7 @@
         <characteristic name="Skills &amp; Traits" typeId="aa6d-1678-d4d2-a97d">Bone Head, Kick Teammate, Mighty Blow (+1), Thick Skull</characteristic>
         <characteristic name="Primary" typeId="fda4-6261-f0d2-ba0d">PS</characteristic>
         <characteristic name="Secondary" typeId="9491-8b10-7b30-9358">AG</characteristic>
-        <characteristic name="Cost" typeId="ee01-7448-8c3f-a882">145000</characteristic>
+        <characteristic name="Cost" typeId="ee01-7448-8c3f-a882">140000</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Fix wrong cost view for Blocker and Runt Punter (145 000 instead of 140 000 and 140 000 instead of 145 000). 
Fix Gnoblar TV value. Gnoblar doesn`t have cost, set 15 000.