### PR TITLE
Halfling Master Chef discount was only applied to Halfling Team (Issue #87)

### DIFF
--- a/Blood Bowl.gst
+++ b/Blood Bowl.gst
@@ -882,7 +882,7 @@ Any time a player is sent off for committing a foul or using a Secret Weapon, yo
             </modifier>
             <modifier type="set" field="ffff-7836-9be4-196c" value="100000">
               <conditions>
-                <condition field="selections" scope="primary-catalogue" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="736e07b6-4458-426e-8cf9-d33860c0c7a7" type="instanceOf"/>
+                <condition field="selections" scope="a6b7-0663-b308-f599" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="43d1-827e-3932-1857" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -5000,7 +5000,7 @@ A player hit by Incorporeal gains the No Hands trait and, if they are in possess
       </profiles>
       <rules>
         <rule id="9219-8555-e542-d6d3" name="Sports Necrotheurge" publicationId="9118-6c97-8006-93a4" page="27" hidden="false">
-          <description>Once per game, a Sports Necrotheurge may cast one of the following spells: Incorporeal, Vanhalable's Danse Macabre</description>
+          <description>Once per game, a Sports Necrotheurge may cast one of the following spells: Incorporeal, Vanhalable&apos;s Danse Macabre</description>
         </rule>
       </rules>
       <categoryLinks>


### PR DESCRIPTION
Resolves #87 

## Old Behavior:
Previously, the discount changing the TV cost of `Halfling Master Chef` from `300,000` to `100,000` only checked if the primary catalog was the Halfling Team catalog

<img width="1550" height="433" alt="image" src="https://github.com/user-attachments/assets/2aaccf6c-549d-4816-b5e8-8abbe24a81c1" />

## New Behavior:
Now, the discount checks that the `Halfling Thimble Cup` selection is selected within the `Team Management` category.
Not ideal, it'd be nicer if we moved team rules to their own category so the query makes more sense but that's a refactor for another time

<img width="1553" height="444" alt="image" src="https://github.com/user-attachments/assets/6ab9eb91-4673-4a6a-a5c8-2494ea50ad3e" />
