### PR TITLE
Skills are now added to Skills & Traits column on skill-up

### DIFF
--- a/Blood Bowl.gst
+++ b/Blood Bowl.gst
@@ -1626,6 +1626,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Catch" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="c329-629e-ecc0-713b" name="Diving Catch" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1642,6 +1645,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Diving Catch" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="f07b-09f1-9f88-ae6b" name="Diving Tackle" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1658,6 +1664,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Diving Tackle" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="bd4c-dac9-e7d1-f47b" name="Jump Up" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1674,6 +1683,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Jump Up" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="4ede-2f80-ca60-b608" name="Sprint" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1690,6 +1702,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Sprint" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="0aa2-ed3d-a7a8-89b4" name="Sidestep" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1706,6 +1721,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Sidestep" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="286b-137e-d683-c2a3" name="Sure Feet" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1722,6 +1740,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Sure Feet" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="30df-c110-f163-220c" name="Dodge" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1738,6 +1759,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Dodge" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="6685-b4e5-531d-e9d7" name="Sneaky Git" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1754,6 +1778,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Sneaky Git" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="851c-f5dc-38d9-d2e5" name="Leap" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1770,6 +1797,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Leap" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="6c6d-47aa-0976-fce0" name="Block" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1786,6 +1816,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Block" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="2e36-5cc6-094e-7cd8" name="Dauntless" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1802,6 +1835,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Dauntless" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="7fa2-3bc2-cc79-aeb1" name="Dirty Player (+1)" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1818,6 +1854,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Dirty Player(+1)" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="e997-6798-c53e-55ad" name="Kick" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1834,6 +1873,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Kick" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="7c48-9997-5ed9-d1f1" name="Fend" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1850,6 +1892,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Fend" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="9f99-32a4-cfb9-3f93" name="Pro" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1866,6 +1911,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Pro" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="be32-bc2b-49b7-1c0e" name="Shadowing" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1882,6 +1930,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Shadowing" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="7e98-5279-b39e-1d73" name="Frenzy" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1898,6 +1949,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Frenzy" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="9b6f-3ef9-1fbc-a48f" name="Strip Ball" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1914,6 +1968,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Strip Ball" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="c1cb-44a9-a187-89a1" name="Sure Hands" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1930,6 +1987,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Sure Hands" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="9a16-b887-4ba8-15c6" name="Wrestle" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1946,6 +2006,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Wrestle" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="95a9-67ee-0356-2dba" name="Tackle" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1962,6 +2025,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Tackle" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="3b20-7735-aaf0-700c" name="Big Hand" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1978,6 +2044,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Big Hand" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="de8d-44b0-5a3a-5ff6" name="Claws" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -1994,6 +2063,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Claws" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="5e29-2928-7d20-99c3" name="Disturbing Presence" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2010,6 +2082,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Disturbing Presence" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="64da-eb16-90a8-7fde" name="Safe Pass" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2026,6 +2101,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Safe Pass" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="5278-4a58-436e-f886" name="Nerves of Steel" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2042,6 +2120,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Nerves of Steel" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="1dce-1f4d-e2b8-8e2f" name="Grab" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2058,6 +2139,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Grab" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="b6ac-e2c8-e0d7-e092" name="Mighty Blow (+1)" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2074,6 +2158,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Mighty Blow (+1)" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="6036-f009-d354-0a40" name="Stand Firm" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2090,6 +2177,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Stand Firm" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="9bbd-7844-16a2-c9fe" name="Thick Skull" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2106,6 +2196,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Thick Skull" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="0ece-9309-c7da-d7a4" name="Break Tackle" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2122,6 +2215,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Break Tackle" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="8e94-6564-5f79-0128" name="Dump-off" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2138,6 +2234,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Dump-Off" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="4ced-cc9b-1a5a-8874" name="Tentacles" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2154,6 +2253,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Tentacles" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="5b4b-d544-c4b1-e5d1" name="Juggernaut" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2170,6 +2272,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Juggernaut" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="12a1-0e6d-edcb-0f8a" name="Hail Mary Pass" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2186,6 +2291,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Hail Mary Pass" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="d8ab-3700-1ec7-d59c" name="Accurate" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2202,6 +2310,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Accurate" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="87dc-1360-433d-baed" name="Guard" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2218,6 +2329,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Guard" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="f2a0-5f3b-f43e-13fa" name="Multiple Block" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2234,6 +2348,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Multiple Block" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="828c-bd4a-fd63-8828" name="Strong Arm" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2250,6 +2367,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Strong Arm" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="cfde-f0d4-4609-cd57" name="Pass" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2266,6 +2386,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Pass" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="5d92-bca6-7d6b-03cd" name="Leader" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2282,6 +2405,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Leader" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="14f3-1ae1-2756-d310" name="Very Long Legs" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2298,6 +2424,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Very Long Legs" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="8e06-673b-e8a4-69b9" name="Prehensile Tail" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2314,6 +2443,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Prehensile Tail" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="0fca-f232-20db-5486" name="Extra Arms" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2330,6 +2462,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Extra Arms" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="bb9c-3ef4-f7a6-9234" name="Foul Appearance" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2346,6 +2481,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Foul Appearance" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="d52e-e727-0ee4-ec85" name="Horns" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2362,6 +2500,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Horns" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="ee92-fa03-9a46-0aa4" name="Two Heads" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -2378,6 +2519,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Two Heads" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="d33f-b5e3-efce-f815" name="+AG" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -3237,6 +3381,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Defensive" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="d44d-4a69-ca9f-ef4c" name="Safe Pair of Hands" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3253,6 +3400,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Safe Pair of Hands" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="f32f-8e0b-95fc-1ece" name="Iron Hard Skin" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3269,6 +3419,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Iron Hard Skin" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="5c37-ab43-92e3-65bd" name="Monstrous Mouth" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3285,6 +3438,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Monstrous Mouth" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="b95c-f05a-93f8-edd8" name="Cloud Burster" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3301,6 +3457,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Cloud Burster" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="5c4d-cb75-ab15-ad49" name="Cannoneer" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3317,6 +3476,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Cannoneer" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="b5e6-5b6a-02b5-5e27" name="Fumblerooskie" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3333,6 +3495,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Fumblerooskie" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="381c-5cad-621e-8e55" name="On the Ball" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3349,6 +3514,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="On the Ball" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="b202-6647-1ae5-3c64" name="Running Pass" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3365,6 +3533,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Running Pass" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="68a7-5f56-92ba-c718" name="Arm Bar" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3381,6 +3552,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Arm Bar" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="5fd2-79a1-26f5-bf4d" name="Brawler" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3397,6 +3571,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Brawler" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="de4d-0c5e-4bb4-7a67" name="Pile Driver" publicationId="46da-ba61-6439-83e5" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -3413,6 +3590,9 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Pile Driver" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="91ba-cf1f-6fd4-6e37" name="Random Secondary Skill" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -5304,6 +5484,9 @@ Until the end of this game, each selected player gains a single randomly selecte
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Portal Navigator" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="43e1-85c4-3832-e605" name="Give and Go" publicationId="439d-dc2e-2f7e-c520" page="67" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -5320,6 +5503,9 @@ Until the end of this game, each selected player gains a single randomly selecte
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Give and Go" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="8be3-afaf-8617-9d13" name="Portal Passer" publicationId="439d-dc2e-2f7e-c520" page="67" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -5336,6 +5522,9 @@ Until the end of this game, each selected player gains a single randomly selecte
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Portal Passer" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="da1a-049a-8559-74db" name="Wall Thrower" publicationId="439d-dc2e-2f7e-c520" page="67" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -5352,6 +5541,9 @@ Until the end of this game, each selected player gains a single randomly selecte
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
+      <modifiers>
+        <modifier type="append" value="Wall Thrower" field="aa6d-1678-d4d2-a97d" affects="ef36-92eb-8b79-1a1f.profiles.Player" scope="root-entry" join=", "/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Breathe Fire" hidden="false" id="4d7a-6919-7659-fee8" publicationId="dcf0-4e1e-b304-926a"/>
     <selectionEntry type="unit" import="true" name="Star Players" hidden="false" id="5ab0-a25e-669e-c9da" subType="unit-group">


### PR DESCRIPTION
Changed each skill so that when they're selected in Advancements they're added
Selection:
<img width="538" height="122" alt="image" src="https://github.com/user-attachments/assets/8c152ab2-f253-4db4-a7fc-9ab0217eaf30" />
Previously:
<img width="786" height="256" alt="image" src="https://github.com/user-attachments/assets/2777b534-cbb4-44ab-84e4-cf21df94301f" />
Now:
<img width="787" height="255" alt="image" src="https://github.com/user-attachments/assets/0a311032-7125-45d6-9f0b-c6c05eb0cc18" />
