### PR TITLE
Gasparen fix snotlings and more

### DIFF
--- a/Amazons.cat
+++ b/Amazons.cat
@@ -120,15 +120,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="4035-2ef0-a904-2a1b" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="f4e0-6ee9-964d-28cf" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="7736-60ac-860c-2343" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Star Players" hidden="false" id="8f98-1dbf-702e-b17d" type="selectionEntry" targetId="5ab0-a25e-669e-c9da">

--- a/Black Orcs.cat
+++ b/Black Orcs.cat
@@ -107,11 +107,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="4bdd-bdfc-4cbc-6fd5" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="1d6c-f3b1-58d0-75bb" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="4a02-7c69-4892-a5b7" name="WAAAGH! Drummer" hidden="false" collective="false" import="true" targetId="54e1-c0ea-1874-f2a9" type="selectionEntry"/>
       </entryLinks>
     </entryLink>

--- a/Blood Bowl.gst
+++ b/Blood Bowl.gst
@@ -11778,7 +11778,7 @@ When using Swarming, a coach may not set up more players wwith the Swarming trai
       <description>If this player is Knocked Down or Placed Prone (but not if they Fall Over) whilst in possession of the ball, the ball does not bounce. Instead, you may place the ball in an unoccupied square adjacent to the one this player occupies when they become Prone. This Skill may still be used if the player is Prone.</description>
     </rule>
     <rule id="1f09-425c-df44-48ec" name="Iron Hard Skin" publicationId="46da-ba61-6439-83e5" page="78" hidden="false">
-      <description>The Claws skill cannot be used when making an Armour roll against this player. This Skill may still be used if the player is Prone, Stunned, or has lost their Tackle Zone.</description>
+      <description>Opposing players cannot modify any Armour rolls made against this player. In addition, the Claws skill cannot be used when making an Armour roll against this player. This Skill may still be used if the player is Prone, Stunned or has lost their Tackle Zone.</description>
     </rule>
     <rule id="988d-1349-9f05-206c" name="Cannoneer" publicationId="46da-ba61-6439-83e5" page="79" hidden="false">
       <description>When this player performs a Long Pass action or a Long Bomb Pass action, you may apply an additional +1 modifier to the Passing Ability test.</description>

--- a/Blood Bowl.gst
+++ b/Blood Bowl.gst
@@ -903,7 +903,7 @@ An apothecary can be used when a player suffers a Badly Hurt, Seriously Hurt or 
             </modifier>
             <modifier type="set" field="ffff-7836-9be4-196c" value="100000">
               <conditions>
-                <condition field="forces" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="736e07b6-4458-426e-8cf9-d33860c0c7a7" type="instanceOf">
+                <condition field="forces" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="736e07b6-4458-426e-8cf9-d33860c0c7a7" type="instanceOf">
                   <comment>As of May 2025 errata, Halfling Master Chef is only 100,000 for Halfling teams, 300,000 for all others</comment>
                 </condition>
               </conditions>
@@ -948,16 +948,9 @@ An apothecary can be used when a player suffers a Badly Hurt, Seriously Hurt or 
         <selectionEntry id="8604-23e5-2fa0-77a3" name="Bribes" publicationId="46da-ba61-6439-83e5" page="91" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="ffff-7836-9be4-196c" value="50000">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab80a28e-58b5-4507-8d15-b56fe8bc6f84" type="instanceOf"/>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ec1f-b097-71ea-f8d3" type="instanceOf"/>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="16fa-fd44-878a-e35b" type="instanceOf"/>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de6eab1a-e3fd-478d-a2cb-2fe495d63138" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="172c-824e-bd16-0edf" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
             </modifier>
           </modifiers>
           <constraints>
@@ -1629,6 +1622,38 @@ PUSHED INTO THE CROWD: If any part of a Giant’s base is pushed off the pitch, 
             <cost name=" TV" typeId="ffff-7836-9be4-196c" value="50000"/>
             <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
           </costs>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Biased Referee" hidden="false" id="10b4-695f-9014-4aea" collective="false">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="force" childId="e070-b4a9-cbf9-7b52" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="95c4-5b96-45cc-9470" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+          <rules>
+            <rule name="Biased Referee" id="7937-938d-b990-2f8a" hidden="false" publicationId="46da-ba61-6439-83e5" page="95">
+              <description>Biased Referees are available to purchase during the pre-game sequence at the cost listed, and because Blood Bowl games tend to be officiated over by a group rather than a single individual, both teams may purchase a Biased Referee. You may purchase one Biased Referee to treat your team favourably during the game ahead.
+
+For the most part, a Biased Referee will treat both teams equally, meaning that they follow all of the normal referee rules as described on page 63. Where they differ is that they will be either far more harsh in their scrutiny of the opposition or far more lenient in their treatment of the team that has paid them off. How this manifests is described in each Biased Referee’s description.
+
+Many Biased Referees are named celebrities, although most are not. As with Star Players, it is possible for both teams to hire the services of the same named Biased Referee:
+
+• If this happens during a game that is part of a league, neither team can use the named Biased Referee but the named Biased Referee will keep both hiring fees.
+• If this happens during exhibition play, both teams can use the named Biased Referee – they can dish out harsh rulings to both sides!</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
+            <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
+            <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
+          </costs>
+          <entryLinks>
+            <entryLink import="true" name="Biased Referee" hidden="false" id="d0d3-9cfa-05d1-162e" type="selectionEntryGroup" targetId="cfaf-b84a-8075-1c2f"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -4627,87 +4652,6 @@ table has already been made, and roll on this table again.
       <costs>
         <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
         <cost name=" TV" typeId="ffff-7836-9be4-196c" value="80000"/>
-        <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f61f-f3ac-6712-ae1d" name="Ranulf &apos;Red&apos; Hokuli" publicationId="9118-6c97-8006-93a4" page="34" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd3a-4844-9907-a5dd" type="max"/>
-      </constraints>
-      <rules>
-        <rule id="439b-363a-f95e-492e" name="&apos;Red&apos; Card" publicationId="9118-6c97-8006-93a4" page="34" hidden="false">
-          <description>If any player on the opposing team commits a Foul but a double is not rolled when making either the Armour roll or Injury roll, roll a D6:
-
-• On a roll of 4+, Ranulf loudly demands that play halt whilst he investigates further.
-• On a roll of 1-3, the player manages to avoid the ref’s attention.
-
-Once spotted by Ranulf in this way (and only in this way), the coach of the player that committed the Foul must choose one of the following options:
-
-• The coach may use a Bribe if one is available.
-• The player that committed the Foul may accept their fate and be Sent-off.
-• The player may attempt to argue with Ranulf! Ranulf will settle the argument with his axe. An Armour roll is made against the player, applying a +2 modifier to the result:
-- If the roll is higher than the Armour Value of the player, they become Prone and an Injury roll is made against them. The player is not Sent-off and no Turnover is caused.
-- If the roll is equal to or lower than the Armour Value of the player hit, the attack has no effect. The player is Sent-off and a Turnover caused.</description>
-        </rule>
-        <rule id="8ef7-6be9-e29c-d8f2" name="&quot;I&apos;m not the one arguing!&quot;" publicationId="9118-6c97-8006-93a4" page="34" hidden="false">
-          <description>If Ranulf has been Induced for this game, even if he does not take part due to both coaches Inducing him, neither coach can Argue the Call – even the most argumentative of coaches can’t help but have respect for the charismatic Norscan.</description>
-        </rule>
-      </rules>
-      <costs>
-        <cost name=" TV" typeId="ffff-7836-9be4-196c" value="120000"/>
-        <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
-        <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7db9-75b4-696b-2fee" name="Thoron Korensson" publicationId="9118-6c97-8006-93a4" page="34" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc6f-7afb-eb77-762a" type="max"/>
-      </constraints>
-      <rules>
-        <rule id="7727-1d11-7314-c522" name="Strict Discipline" publicationId="9118-6c97-8006-93a4" page="34" hidden="false">
-          <description>If any player on the opposing team commits a Foul but a double is not rolled when making either the Armour roll or Injury roll, roll a D6:
-
-• On a roll of 4+, Korensson has spotted the violation.
-• On a roll of 1-3, the player manages to avoid the ref’s attention.
-
-Once spotted by Korensson in this way (and only in this way), the player that committed the Foul is immediately Sent-off. When a player is Sent-off in this way, their coach cannot use a Bribe but may attempt to Argue the Call. However, if a 1 is rolled on the Argue the Call table, not only is the player and the coach Sent-off, but one other randomly selected player belonging to the opposing team and that is currently on the pitch is Sent-off as well.</description>
-        </rule>
-        <rule id="2eef-5b0a-7e11-48f7" name="&quot;Sit down and keep quiet&quot;" publicationId="9118-6c97-8006-93a4" page="34" hidden="false">
-          <description>If a Get the Ref result is rolled on the Kick-off Event table, roll again – it takes a particularly riled-up crowd to want to advance on Korensson.</description>
-        </rule>
-      </rules>
-      <costs>
-        <cost name=" TV" typeId="ffff-7836-9be4-196c" value="120000"/>
-        <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
-        <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="10b4-695f-9014-4aea" name="Biased Referee" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e070-b4a9-cbf9-7b52" type="instanceOf"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95c4-5b96-45cc-9470" type="max"/>
-      </constraints>
-      <rules>
-        <rule id="7937-938d-b990-2f8a" name="Biased Referee" publicationId="46da-ba61-6439-83e5" page="95" hidden="false">
-          <description>Biased Referees are available to purchase during the pre-game sequence at the cost listed, and because Blood Bowl games tend to be officiated over by a group rather than a single individual, both teams may purchase a Biased Referee. You may purchase one Biased Referee to treat your team favourably during the game ahead.
-
-For the most part, a Biased Referee will treat both teams equally, meaning that they follow all of the normal referee rules as described on page 63. Where they differ is that they will be either far more harsh in their scrutiny of the opposition or far more lenient in their treatment of the team that has paid them off. How this manifests is described in each Biased Referee’s description.
-
-Many Biased Referees are named celebrities, although most are not. As with Star Players, it is possible for both teams to hire the services of the same named Biased Referee:
-
-• If this happens during a game that is part of a league, neither team can use the named Biased Referee but the named Biased Referee will keep both hiring fees.
-• If this happens during exhibition play, both teams can use the named Biased Referee – they can dish out harsh rulings to both sides!</description>
-        </rule>
-      </rules>
-      <costs>
-        <cost name=" TV" typeId="ffff-7836-9be4-196c" value="0"/>
-        <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
         <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
       </costs>
     </selectionEntry>
@@ -11154,20 +11098,20 @@ Until the end of this game, each selected player gains the Pro skill. However, a
             <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
             <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
           </costs>
+          <modifiers>
+            <modifier type="set" value="80000" field="ffff-7836-9be4-196c">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="172c-824e-bd16-0edf" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry id="dcaa-7186-6b12-e32f" name="Jorm the Ogre" publicationId="9118-6c97-8006-93a4" page="35" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="ffff-7836-9be4-196c" value="80000">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab80a28e-58b5-4507-8d15-b56fe8bc6f84" type="instanceOf"/>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ec1f-b097-71ea-f8d3" type="instanceOf"/>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="16fa-fd44-878a-e35b" type="instanceOf"/>
-                    <condition field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de6eab1a-e3fd-478d-a2cb-2fe495d63138" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="172c-824e-bd16-0edf" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
             </modifier>
           </modifiers>
           <constraints>
@@ -11196,7 +11140,7 @@ Once spotted by Jorm in this way (and only in this way), the player that committ
           <modifiers>
             <modifier type="set" field="ffff-7836-9be4-196c" value="40000">
               <conditions>
-                <condition field="selections" scope="primary-catalogue" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="736e07b6-4458-426e-8cf9-d33860c0c7a7" type="instanceOf"/>
+                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="43d1-827e-3932-1857" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -11223,6 +11167,77 @@ Once spotted by Jorm in this way (and only in this way), the player that committ
             <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
             <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
           </costs>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Ranulf &apos;Red&apos; Hokuli" hidden="true" id="f61f-f3ac-6712-ae1d" publicationId="9118-6c97-8006-93a4" page="34" collective="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fd3a-4844-9907-a5dd" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+          <rules>
+            <rule name="&apos;Red&apos; Card" id="439b-363a-f95e-492e" hidden="false" publicationId="9118-6c97-8006-93a4" page="34">
+              <description>If any player on the opposing team commits a Foul but a double is not rolled when making either the Armour roll or Injury roll, roll a D6:
+
+• On a roll of 4+, Ranulf loudly demands that play halt whilst he investigates further.
+• On a roll of 1-3, the player manages to avoid the ref’s attention.
+
+Once spotted by Ranulf in this way (and only in this way), the coach of the player that committed the Foul must choose one of the following options:
+
+• The coach may use a Bribe if one is available.
+• The player that committed the Foul may accept their fate and be Sent-off.
+• The player may attempt to argue with Ranulf! Ranulf will settle the argument with his axe. An Armour roll is made against the player, applying a +2 modifier to the result:
+- If the roll is higher than the Armour Value of the player, they become Prone and an Injury roll is made against them. The player is not Sent-off and no Turnover is caused.
+- If the roll is equal to or lower than the Armour Value of the player hit, the attack has no effect. The player is Sent-off and a Turnover caused.</description>
+            </rule>
+            <rule name="&quot;I&apos;m not the one arguing!&quot;" id="8ef7-6be9-e29c-d8f2" hidden="false" publicationId="9118-6c97-8006-93a4" page="34">
+              <description>If Ranulf has been Induced for this game, even if he does not take part due to both coaches Inducing him, neither coach can Argue the Call – even the most argumentative of coaches can’t help but have respect for the charismatic Norscan.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name=" TV" typeId="ffff-7836-9be4-196c" value="130000"/>
+            <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
+            <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="5581-bb5e-6d85-79d8" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="4003-dd1b-d594-1051" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Thoron Korensson" hidden="true" id="7db9-75b4-696b-2fee" publicationId="9118-6c97-8006-93a4" page="34" collective="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fc6f-7afb-eb77-762a" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+          <rules>
+            <rule name="Strict Discipline" id="7727-1d11-7314-c522" hidden="false" publicationId="9118-6c97-8006-93a4" page="34">
+              <description>If any player on the opposing team commits a Foul but a double is not rolled when making either the Armour roll or Injury roll, roll a D6:
+
+• On a roll of 4+, Korensson has spotted the violation.
+• On a roll of 1-3, the player manages to avoid the ref’s attention.
+
+Once spotted by Korensson in this way (and only in this way), the player that committed the Foul is immediately Sent-off. When a player is Sent-off in this way, their coach cannot use a Bribe but may attempt to Argue the Call. However, if a 1 is rolled on the Argue the Call table, not only is the player and the coach Sent-off, but one other randomly selected player belonging to the opposing team and that is currently on the pitch is Sent-off as well.</description>
+            </rule>
+            <rule name="&quot;Sit down and keep quiet&quot;" id="2eef-5b0a-7e11-48f7" hidden="false" publicationId="9118-6c97-8006-93a4" page="34">
+              <description>If a Get the Ref result is rolled on the Kick-off Event table, roll again – it takes a particularly riled-up crowd to want to advance on Korensson.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name=" TV" typeId="ffff-7836-9be4-196c" value="120000"/>
+            <cost name=" Total SPP" typeId="39e2-ec20-0c67-eba6" value="0"/>
+            <cost name=" Used SPP" typeId="069c-526e-7481-6bb7" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="d5be-b66d-7065-f9af" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>

--- a/Chaos Chosen.cat
+++ b/Chaos Chosen.cat
@@ -136,11 +136,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="e899-a475-0b85-9c4b" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="2e95-ce68-c510-fe6a" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="a348-8d7b-e9dc-3555" name="Apothecary" hidden="false" collective="false" import="true" targetId="77da-bfcb-d236-80a8" type="selectionEntry">

--- a/Chaos Dwarfs.cat
+++ b/Chaos Dwarfs.cat
@@ -131,15 +131,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="b2d0-42ce-2b9f-1f90" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="64cf-cf82-5336-08dd" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="9ccd-b2f7-0525-0f56" name="Thoron Korensson" hidden="false" collective="false" import="true" targetId="7db9-75b4-696b-2fee" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="0dc9-1cf1-a1b5-f5b1" name="Apothecary" hidden="false" collective="false" import="true" targetId="77da-bfcb-d236-80a8" type="selectionEntry">

--- a/Chaos Renegades.cat
+++ b/Chaos Renegades.cat
@@ -211,11 +211,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="1cc2-fdad-cc94-43cc" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="2b1d-0441-8a3b-214c" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="5a4b-c58c-3ae0-e357" name="Apothecary" hidden="false" collective="false" import="true" targetId="77da-bfcb-d236-80a8" type="selectionEntry">

--- a/Dark Elves.cat
+++ b/Dark Elves.cat
@@ -132,11 +132,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="d5a2-cc3e-f5c9-ab91" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="274e-cd16-f50c-eeab" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="2c84-0f14-7d2b-cc95" name="Apothecary" hidden="false" collective="false" import="true" targetId="77da-bfcb-d236-80a8" type="selectionEntry">

--- a/Dwarves.cat
+++ b/Dwarves.cat
@@ -131,16 +131,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="0f62-5c1c-bbd2-8eee" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="e615-903f-fba1-5356" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="6428-47a6-9faa-0fec" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-                <entryLink id="5daf-c684-4cb1-0ef6" name="Thoron Korensson" hidden="false" collective="false" import="true" targetId="7db9-75b4-696b-2fee" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
         <entryLink id="70fa-4789-609e-c7d0" name="Halfling Hot Pot" hidden="false" collective="false" import="true" targetId="74f2-37ae-f8a2-ad5e" type="selectionEntry"/>
         <entryLink id="c90c-9cec-7e17-3104" name="Master of Ballistics" hidden="false" collective="false" import="true" targetId="157f-649b-9c97-9e54" type="selectionEntry"/>
         <entryLink id="19b3-4023-b4b4-2d32" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>

--- a/Elven Union.cat
+++ b/Elven Union.cat
@@ -117,11 +117,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="99d2-6ca7-bdb8-75c4" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="bbb5-05e9-7744-a539" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="f00c-c351-243a-1e4b" name="Apothecary" hidden="false" collective="false" import="true" targetId="77da-bfcb-d236-80a8" type="selectionEntry">

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -980,6 +980,7 @@
             <modifier type="increment" field="ffff-7836-9be4-196c" value="20000">
               <repeats>
                 <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8179-7288-9a95-6d70" repeats="1" roundUp="false"/>
+                <repeat value="1" repeats="1" field="selections" scope="parent" childId="8fc3-9567-73bd-8337" shared="true" roundUp="false" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e070-b4a9-cbf9-7b52" type="instanceOf"/>
@@ -989,7 +990,6 @@
               <repeats>
                 <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6560-e720-c923-72ae" repeats="1" roundUp="false"/>
                 <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f4e-0b58-0fc3-0fa0" repeats="1" roundUp="false"/>
-                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8fc3-9567-73bd-8337" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e070-b4a9-cbf9-7b52" type="instanceOf"/>
@@ -1014,12 +1014,12 @@
                 <entryLink id="4f69-1d5a-5474-c8e5" name="Primary Skills" hidden="false" collective="false" import="true" targetId="968e-d5f0-3736-bf3e" type="selectionEntryGroup">
                   <entryLinks>
                     <entryLink id="011e-b1f6-480e-80db" name="[A]gility" hidden="false" collective="false" import="true" targetId="79de-c235-bfc5-de8b" type="selectionEntryGroup"/>
+                    <entryLink import="true" name="[P]asssing" hidden="false" id="a701-34c3-2d48-c4c0" collective="false" targetId="5560-9934-18c8-47ed" type="selectionEntryGroup"/>
                   </entryLinks>
                 </entryLink>
                 <entryLink id="8b97-e624-e89a-fb41" name="Secondary Skills" hidden="false" collective="false" import="true" targetId="d785-45e4-f9a9-ba02" type="selectionEntryGroup">
                   <entryLinks>
                     <entryLink id="e221-2c8d-1eb7-30fb" name="[G]eneral" hidden="false" collective="false" import="true" targetId="45d4-02a0-b7b2-b9df" type="selectionEntryGroup"/>
-                    <entryLink id="a701-34c3-2d48-c4c0" name="[P]asssing" hidden="false" collective="false" import="true" targetId="5560-9934-18c8-47ed" type="selectionEntryGroup"/>
                     <entryLink id="2048-d30f-57f5-e9ac" name="[S]trength" hidden="false" collective="false" import="true" targetId="7202-217b-ff0b-e506" type="selectionEntryGroup"/>
                   </entryLinks>
                 </entryLink>
@@ -3441,7 +3441,7 @@
               <modifiers>
                 <modifier type="set" field="ee01-7448-8c3f-a882" value="75000"/>
                 <modifier type="set" field="aa6d-1678-d4d2-a97d" value="Bombardier, Dodge, Loner (4+), Secret Weapon, Stunty"/>
-                <modifier type="set" field="name" value="Mercenary [Bombardier]"/>
+                <modifier type="set" field="name" value="Mercenary [Bomma]"/>
               </modifiers>
             </modifierGroup>
           </modifierGroups>
@@ -3465,6 +3465,7 @@
           </constraints>
           <entryLinks>
             <entryLink id="4c2d-3ad9-5b36-b840" name="[A]gility" hidden="false" collective="false" import="true" targetId="79de-c235-bfc5-de8b" type="selectionEntryGroup"/>
+            <entryLink import="true" name="[P]asssing" hidden="false" id="1f21-05ca-6348-5a0b" collective="false" targetId="5560-9934-18c8-47ed" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -3826,8 +3827,8 @@
         <characteristic name="PA" typeId="90cd-0493-9510-60b5">4</characteristic>
         <characteristic name="AV" typeId="c77a-49e5-750a-1adc">8</characteristic>
         <characteristic name="Skills &amp; Traits" typeId="aa6d-1678-d4d2-a97d">Bombardier, Dodge, Secret Weapon, Stunty</characteristic>
-        <characteristic name="Primary" typeId="fda4-6261-f0d2-ba0d">A</characteristic>
-        <characteristic name="Secondary" typeId="9491-8b10-7b30-9358">GPS</characteristic>
+        <characteristic name="Primary" typeId="fda4-6261-f0d2-ba0d">AP</characteristic>
+        <characteristic name="Secondary" typeId="9491-8b10-7b30-9358">GS</characteristic>
         <characteristic name="Cost" typeId="ee01-7448-8c3f-a882">45000</characteristic>
       </characteristics>
     </profile>

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -186,11 +186,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="4bd8-9330-211a-cebb" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="a33e-b1ae-5726-d97f" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="6822-d12d-dff3-7f56" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>
         <entryLink id="b83b-02c8-bff1-2f48" name="Bottles of Heady Brew" hidden="false" collective="false" import="true" targetId="b891-67b6-6431-70ce" type="selectionEntry"/>
         <entryLink id="1d95-c7ad-ca5c-a71a" name="WAAAGH! Drummer" hidden="false" collective="false" import="true" targetId="54e1-c0ea-1874-f2a9" type="selectionEntry"/>

--- a/Halflings.cat
+++ b/Halflings.cat
@@ -116,15 +116,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="8933-3936-d6a9-d8fe" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="257e-a35a-8824-ba8e" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="14b4-4994-dc0b-05c0" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
         <entryLink id="9971-7c3a-8d00-d349" name="Halfling Hot Pot" hidden="false" collective="false" import="true" targetId="74f2-37ae-f8a2-ad5e" type="selectionEntry">
           <costs>
             <cost name=" TV" typeId="ffff-7836-9be4-196c" value="60000"/>

--- a/High Elves.cat
+++ b/High Elves.cat
@@ -122,11 +122,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="7f5b-0771-fcaf-493a" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="5378-82f9-4846-d175" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Star Players" hidden="false" id="d231-2bc6-c726-de68" type="selectionEntry" targetId="5ab0-a25e-669e-c9da"/>

--- a/Humans.cat
+++ b/Humans.cat
@@ -146,15 +146,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="4706-e43a-d46e-3cbf" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="a3e8-9db7-e20f-a19a" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="7062-41e0-6d59-9e58" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
         <entryLink id="54dd-49b7-7ebd-c77e" name="Halfling Hot Pot" hidden="false" collective="false" import="true" targetId="74f2-37ae-f8a2-ad5e" type="selectionEntry"/>
         <entryLink id="e607-63f7-49e6-1c3c" name="Master of Ballistics" hidden="false" collective="false" import="true" targetId="157f-649b-9c97-9e54" type="selectionEntry"/>
         <entryLink id="cc53-3113-0d05-2444" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>

--- a/Imperial Nobility.cat
+++ b/Imperial Nobility.cat
@@ -136,15 +136,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="50ad-b58b-dc62-f763" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="ac60-3270-af94-a552" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="fb07-ac38-222b-babd" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
         <entryLink id="5b6b-b2a4-a46c-acd8" name="Halfling Hot Pot" hidden="false" collective="false" import="true" targetId="74f2-37ae-f8a2-ad5e" type="selectionEntry"/>
         <entryLink id="7381-0873-c61b-73c3" name="Master of Ballistics" hidden="false" collective="false" import="true" targetId="157f-649b-9c97-9e54" type="selectionEntry"/>
         <entryLink id="2c71-16bf-15ea-deaf" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>

--- a/Khorne.cat
+++ b/Khorne.cat
@@ -126,11 +126,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="d240-d430-11a0-9c9f" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="fe14-cc37-b29e-b52b" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Star Players" hidden="false" id="0c68-544e-80db-ffcf" type="selectionEntry" targetId="5ab0-a25e-669e-c9da"/>

--- a/Lizardmen.cat
+++ b/Lizardmen.cat
@@ -125,15 +125,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="0c1d-7493-61fb-7874" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="8aba-2741-bdd5-a957" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="d998-2a6a-d2f6-c8d2" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Star Players" hidden="false" id="1407-91ba-5f9a-5e9f" type="selectionEntry" targetId="5ab0-a25e-669e-c9da">

--- a/Necromantic Horror.cat
+++ b/Necromantic Horror.cat
@@ -130,11 +130,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="329e-64e0-f601-b9f1" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="3681-84a0-9093-c0e4" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="bcd8-367a-979e-4b9e" name="Mortuary Assistant" hidden="false" collective="false" import="true" targetId="5f7b-5fc3-e8b6-68e9" type="selectionEntry"/>
       </entryLinks>
     </entryLink>

--- a/Norse.cat
+++ b/Norse.cat
@@ -237,23 +237,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="00bd-28a8-56cc-3702" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="556c-b116-bfff-9809" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="0388-f70e-8077-e3e4" name="Ranulf &apos;Red&apos; Hokuli" hidden="true" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4003-dd1b-d594-1051" type="atLeast"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
         <entryLink id="c55a-c5f7-737d-35ca" name="Halfling Hot Pot" hidden="true" collective="false" import="true" targetId="74f2-37ae-f8a2-ad5e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">

--- a/Nurgle.cat
+++ b/Nurgle.cat
@@ -116,11 +116,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="4a75-fa8a-b80a-f6a7" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="c8d5-4583-eac0-06c7" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="4dd6-5a74-9a72-dd8e" name="Cavorting Nurglings" hidden="false" collective="false" import="true" targetId="6905-bc49-6842-6a0a" type="selectionEntry"/>
         <entryLink id="a833-e888-0be1-bb6c" name="Plague Doctor" hidden="false" collective="false" import="true" targetId="8b0d-3a3e-dcff-49ce" type="selectionEntry"/>
       </entryLinks>

--- a/Ogres.cat
+++ b/Ogres.cat
@@ -103,12 +103,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="cdf4-6b2d-f63e-f60e" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="39e0-2563-80f1-8769" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-            <entryLink id="a3b2-7c7c-6245-5a53" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="e8bd-918c-14b7-0f58" name="WAAAGH! Drummer" hidden="false" collective="false" import="true" targetId="54e1-c0ea-1874-f2a9" type="selectionEntry"/>
         <entryLink id="6b03-10cd-b163-eba1" name="Dwarfen Runesmith" hidden="false" collective="false" import="true" targetId="d481-a4bd-f6dc-c43d" type="selectionEntry"/>
         <entryLink id="2504-c8d4-5787-fabc" name="Halfling Hot Pot" hidden="false" collective="false" import="true" targetId="74f2-37ae-f8a2-ad5e" type="selectionEntry"/>

--- a/Old World Alliance.cat
+++ b/Old World Alliance.cat
@@ -226,15 +226,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="d204-1fa6-a73b-809d" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="67bd-dd6f-940f-19a6" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="c7c6-3f8f-a707-4835" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
         <entryLink id="403f-91ff-639c-dfe8" name="Halfling Hot Pot" hidden="false" collective="false" import="true" targetId="74f2-37ae-f8a2-ad5e" type="selectionEntry"/>
         <entryLink id="170b-fa4f-efad-fa54" name="Master of Ballistics" hidden="false" collective="false" import="true" targetId="157f-649b-9c97-9e54" type="selectionEntry"/>
         <entryLink id="7efa-caa9-8574-ac67" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -147,11 +147,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="a98b-3026-4a4a-8f75" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="f2fd-6118-6003-51c7" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="a17f-1d18-7944-67ad" name="WAAAGH! Drummer" hidden="false" collective="false" import="true" targetId="54e1-c0ea-1874-f2a9" type="selectionEntry"/>
       </entryLinks>
     </entryLink>

--- a/Shambling Undead.cat
+++ b/Shambling Undead.cat
@@ -135,11 +135,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="4c22-b192-6655-34f4" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="7ff2-f39b-7045-4e2b" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="010b-2267-b7fe-00d9" name="Mortuary Assistant" hidden="false" collective="false" import="true" targetId="5f7b-5fc3-e8b6-68e9" type="selectionEntry"/>
       </entryLinks>
     </entryLink>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -140,11 +140,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="12ec-9256-e67e-ea4b" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="8453-f46d-15c8-ad69" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="5d7a-37fe-5990-7388" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>
       </entryLinks>
     </entryLink>

--- a/Slann (NAF).cat
+++ b/Slann (NAF).cat
@@ -120,15 +120,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="4b7b-aae2-ac13-08a7" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="dcc8-949a-7e67-8154" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup">
-              <entryLinks>
-                <entryLink id="8252-fa30-5dfe-6145" name="Ranulf &apos;Red&apos; Hokuli" hidden="false" collective="false" import="true" targetId="f61f-f3ac-6712-ae1d" type="selectionEntry"/>
-              </entryLinks>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Star Players" hidden="false" id="fccf-88ae-6f66-521d" type="selectionEntry" targetId="5ab0-a25e-669e-c9da">

--- a/Snotlings.cat
+++ b/Snotlings.cat
@@ -210,6 +210,7 @@
         <categoryLink id="5b92-84d6-7833-467f" name="Mercenary" hidden="false" targetId="625c-de63-0116-92fb" primary="false"/>
         <categoryLink id="6b9d-6c5c-1b8b-f840" name="Players" hidden="false" targetId="ef36-92eb-8b79-1a1f" primary="false"/>
         <categoryLink id="32f4-4972-e95d-cd05" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="fb72-152e-ee1e-4add" id="52ee-803b-01ff-6e38" primary="false" name="Trained Troll"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ef0a-48e6-f039-d016" name="Mercenary Skill" hidden="false" collective="false" import="true">
@@ -424,8 +425,8 @@
         <infoLink id="ac57-1b13-62a1-eeb1" name="Pogo Stick" hidden="false" targetId="8008-4f05-0fb1-e66d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0d0a-d08a-088a-c397" name="Snotling Lineman" hidden="false" targetId="c04f-1ba4-cbdc-77e3" primary="false"/>
         <categoryLink id="cc4c-d71e-8c99-b723" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="1652-a2d1-b0b6-a1e6" id="3934-9acf-55ba-1458" primary="false" name="Fun-hoppa"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6882-6fe9-26d4-9c8b" name="Career" hidden="false" collective="false" import="true" targetId="a9f9-2fd7-71ab-0b5d" type="selectionEntryGroup"/>
@@ -784,8 +785,8 @@
         <infoLink id="cc55-37f5-43da-59df" name="Secret Weapon" hidden="false" targetId="0a92-31d7-9522-6618" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="67a3-9d9f-2518-7b85" name="Snotling Lineman" hidden="false" targetId="c04f-1ba4-cbdc-77e3" primary="false"/>
         <categoryLink id="0aa3-755d-b83e-c9c8" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="c302-4c50-b589-3b8b" id="4140-8b5d-effd-6712" primary="false" name="Fungus Flinga"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="568f-7982-17e6-5896" name="Career" hidden="false" collective="false" import="true" targetId="a9f9-2fd7-71ab-0b5d" type="selectionEntryGroup"/>
@@ -1152,8 +1153,8 @@
         <infoLink id="0921-b5ef-05ef-8148" name="Sprint" hidden="false" targetId="9b52-0018-4d6b-5525" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2d73-7014-657a-9bae" name="Snotling Lineman" hidden="false" targetId="c04f-1ba4-cbdc-77e3" primary="false"/>
         <categoryLink id="6556-e5e4-e63c-0044" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="8646-aa35-9ab8-ce5f" id="db0c-b1b7-a20b-8e37" primary="false" name="Stilty Runna"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0476-ec3d-1633-282b" name="Career" hidden="false" collective="false" import="true" targetId="a9f9-2fd7-71ab-0b5d" type="selectionEntryGroup"/>
@@ -1579,7 +1580,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bae6-52cf-fb23-cdc3" name="Pump Wagon" hidden="false" targetId="ea55-b190-5b8e-2095" primary="false"/>
-        <categoryLink id="aeee-6b36-c5f3-d60f" name="Trained Troll" hidden="false" targetId="fb72-152e-ee1e-4add" primary="false"/>
         <categoryLink id="ab52-cda0-3e31-f270" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -2190,10 +2190,10 @@
         <infoLink id="5804-3366-0a3e-37cc" name="Loner (4+)" hidden="false" targetId="b448-c8db-4598-1aab" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="54f5-38dd-5529-b830" name="Snotling Lineman" hidden="false" targetId="c04f-1ba4-cbdc-77e3" primary="false"/>
         <categoryLink id="7a42-35c7-a1a6-17e3" name="Players" hidden="false" targetId="ef36-92eb-8b79-1a1f" primary="false"/>
         <categoryLink id="0bdc-679c-6160-f07c" name="Mercenary" hidden="false" targetId="625c-de63-0116-92fb" primary="false"/>
         <categoryLink id="d496-5a6a-b684-7dd7" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="1652-a2d1-b0b6-a1e6" id="1531-cfc1-7f10-1f0b" primary="false" name="Fun-hoppa"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="35b9-6f5c-68ca-ce9d" name="Mercenary Skill" hidden="false" collective="false" import="true">
@@ -2240,10 +2240,10 @@
         <infoLink id="8923-475f-d1a3-4f0c" name="Loner (4+)" hidden="false" targetId="b448-c8db-4598-1aab" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1e32-8a81-cd67-1cce" name="Snotling Lineman" hidden="false" targetId="c04f-1ba4-cbdc-77e3" primary="false"/>
         <categoryLink id="a89e-ac3a-c457-d2b6" name="Players" hidden="false" targetId="ef36-92eb-8b79-1a1f" primary="false"/>
         <categoryLink id="f2c4-439b-e134-bd19" name="Mercenary" hidden="false" targetId="625c-de63-0116-92fb" primary="false"/>
         <categoryLink id="e13b-2e21-6a61-017c" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="c302-4c50-b589-3b8b" id="bd80-2332-defe-ccc5" primary="false" name="Fungus Flinga"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="a6c8-f3a4-fcac-83e3" name="Mercenary Skill" hidden="false" collective="false" import="true">
@@ -2292,7 +2292,6 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7461-1e9c-6fd4-acfd" name="Pump Wagon" hidden="false" targetId="ea55-b190-5b8e-2095" primary="false"/>
-        <categoryLink id="13a9-9770-0093-feb3" name="Trained Troll" hidden="false" targetId="fb72-152e-ee1e-4add" primary="false"/>
         <categoryLink id="3c49-6106-f8b9-905f" name="Mercenary" hidden="false" targetId="625c-de63-0116-92fb" primary="false"/>
         <categoryLink id="d7bd-6946-4f82-be2e" name="Players" hidden="false" targetId="ef36-92eb-8b79-1a1f" primary="false"/>
         <categoryLink id="b5a8-03ba-edfb-b0d0" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
@@ -2341,10 +2340,10 @@
         <infoLink id="ada0-2c6c-eea8-1d1d" name="Loner (4+)" hidden="false" targetId="b448-c8db-4598-1aab" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="50ef-cbd8-e7bf-7932" name="Snotling Lineman" hidden="false" targetId="c04f-1ba4-cbdc-77e3" primary="false"/>
         <categoryLink id="1d6e-02d5-a033-753d" name="Mercenary" hidden="false" targetId="625c-de63-0116-92fb" primary="false"/>
         <categoryLink id="6b1c-e27b-1e20-b482" name="Players" hidden="false" targetId="ef36-92eb-8b79-1a1f" primary="false"/>
         <categoryLink id="22c5-1762-bdb5-01b1" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="8646-aa35-9ab8-ce5f" id="d0e2-53f6-00cf-94f0" primary="false" name="Stilty Runna"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="aae9-8a80-8d00-38a1" name="Mercenary Skill" hidden="false" collective="false" import="true">
@@ -2562,6 +2561,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c265-5747-ba7a-09c0" name="Positionals" hidden="false" targetId="df0d-1d00-1bf7-958f" primary="false"/>
+        <categoryLink targetId="fb72-152e-ee1e-4add" id="5806-a338-bd7a-e72b" primary="false" name="Trained Troll"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="f004-1520-76ad-4c1f" name="Career" hidden="false" collective="false" import="true" targetId="a9f9-2fd7-71ab-0b5d" type="selectionEntryGroup"/>

--- a/Snotlings.cat
+++ b/Snotlings.cat
@@ -150,11 +150,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="a259-b960-fc47-665f" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="f4f4-4841-744d-23ba" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="06d5-c231-c818-c716" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>
         <entryLink id="e4a5-532e-1e0f-b68e" name="Bottles of Heady Brew" hidden="false" collective="false" import="true" targetId="b891-67b6-6431-70ce" type="selectionEntry"/>
         <entryLink id="2565-1ca0-442b-4517" name="Riotous Rookies" hidden="false" collective="false" import="true" targetId="4361-1f5a-b2d3-901c" type="selectionEntry"/>

--- a/Tomb Kings.cat
+++ b/Tomb Kings.cat
@@ -93,7 +93,7 @@
           <entryLinks>
             <entryLink id="1eec-2970-62ba-cac7" name="(In)Famous Coaching Staff" hidden="false" collective="false" import="true" targetId="3a41-d8e0-044c-2580" type="selectionEntryGroup">
               <entryLinks>
-                <entryLink id="e0a3-05fb-17be-2e42" name="Professor Fronkelheim" hidden="false" collective="false" import="true" targetId="b271-e78e-eae2-ab80" type="selectionEntry"/>
+                <entryLink id="e0a3-05fb-17be-2e42" name="Professor Frönkelheim" hidden="false" collective="false" import="true" targetId="b271-e78e-eae2-ab80" type="selectionEntry"/>
               </entryLinks>
             </entryLink>
           </entryLinks>
@@ -113,11 +113,6 @@
                 <entryLink id="7e9c-50b9-f0f3-4426" name="Wicked Witch" hidden="false" collective="false" import="true" targetId="0ece-1731-f4ae-1263" type="selectionEntry"/>
               </entryLinks>
             </entryLink>
-          </entryLinks>
-        </entryLink>
-        <entryLink id="8780-5f17-6f8a-5403" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="8364-3893-5cdb-afd2" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
           </entryLinks>
         </entryLink>
         <entryLink id="0fd4-4349-25ae-80d6" name="Mortuary Assistant" hidden="false" collective="false" import="true" targetId="5f7b-5fc3-e8b6-68e9" type="selectionEntry"/>

--- a/Underworld Denizens.cat
+++ b/Underworld Denizens.cat
@@ -185,11 +185,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="e127-55a0-584c-15f0" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="6386-3915-daff-d01d" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="5327-d0b0-2f34-f405" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>
       </entryLinks>
     </entryLink>

--- a/Vampires.cat
+++ b/Vampires.cat
@@ -95,11 +95,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="546d-b0fc-f98a-8fd3" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="f579-0cc5-2c8d-0ff1" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
         <entryLink id="7269-1299-76c4-242d" name="Mortuary Assistant" hidden="false" collective="false" import="true" targetId="5f7b-5fc3-e8b6-68e9" type="selectionEntry"/>
         <entryLink id="4888-ee46-6924-8ab4" name="Wandering Apothecaries" hidden="false" collective="false" import="true" targetId="5564-dcac-1706-7a79" type="selectionEntry"/>
       </entryLinks>
@@ -675,8 +670,7 @@
         <rule id="61f6-ab9c-a86f-99a3" name="Vampire Lord" publicationId="5dbd-3c70-d864-0f43" hidden="false">
           <description>The Head Coach of this team is replaced by a Vampire Lord. Once per game, during the post-game sequence, they can &apos;Summon a Thrall&apos;:
 
-• If a player on the opposing team with a Strength characteristic of 4 or less and that did not have the Regeneration or Stunty traits suffered a Casualty result of 15 or 16, DEAD during the game, and if they could not be saved by an apothecary, during Step 4 of the post-game sequence a single new rookie Thrall Lineman player may be permanently hired for free if the team has fewer than 16 players on its team draft list, otherwise it will be lost. The Thrall Lineman&apos;s full value still counts towards the Actual Team Value.
-</description>
+• If a player on the opposing team with a Strength characteristic of 4 or less and that did not have the Regeneration or Stunty traits suffered a Casualty result of 15 or 16, DEAD during the game, and if they could not be saved by an apothecary, during Step 4 of the post-game sequence a single new rookie Thrall Lineman player may be permanently hired for free if the team has fewer than 16 players on its team draft list, otherwise it will be lost. The Thrall Lineman&apos;s full value still counts towards the Actual Team Value.</description>
         </rule>
       </rules>
       <costs>

--- a/Wood Elves.cat
+++ b/Wood Elves.cat
@@ -137,11 +137,6 @@
             </entryLink>
           </entryLinks>
         </entryLink>
-        <entryLink id="9e5f-44f6-fe36-7539" name="Biased Referee" hidden="false" collective="false" import="true" targetId="10b4-695f-9014-4aea" type="selectionEntry">
-          <entryLinks>
-            <entryLink id="2fb3-420d-9bef-1b2e" name="Biased Referee" hidden="false" collective="false" import="true" targetId="cfaf-b84a-8075-1c2f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Star Players" hidden="false" id="ab16-d16d-2475-0b92" type="selectionEntry" targetId="5ab0-a25e-669e-c9da"/>


### PR DESCRIPTION
Closes #89 - While doing this also changed how "Biased Referee" inducement work so that it now changes visibility and costs using Team Special Rules instead of manually adding it.
Closes #103 - Replaced text
Closes #112 - Categories were wrong, now this has been corrected
Closes #110 - Moved Passing to Primary for Goblin Bomma

With the Biased Referee modification all of the teams were changed, hence the amount of files touched